### PR TITLE
Add parameter to remove valid check from validaiton output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
     output in a character vector with a slightly different format (#39)
 -   add `ignore_val_err` parameter in the `validate_submission()` function to 
     ignore stopping the validation if any `[valid_vals]` error (#40)
+-   add parameter `store_msg_val()` function to remove valid check (and non 
+    compound id check) on output of the function (#44)
 
 # SMHvalidation 1.0.0
 

--- a/R/imports-hubValidations.R
+++ b/R/imports-hubValidations.R
@@ -242,11 +242,13 @@ is_check_class <- function(x,
 #' Store validation output in a simple object
 #'
 #' @param msg validation output
+#' @param rm_valid_check Boolean, remove valid check and `spl_non_compound`
+#' output, by default FALSE.
 #'
 #' @importFrom dplyr case_when
 #' @importFrom purrr map_chr
 #' @export
-store_msg_val <- function(msg) {
+store_msg_val <- function(msg, rm_valid_check = FALSE) {
   txt <- paste(
     dplyr::case_when(is_check_class(msg, "check_success") ~ "\U002705",
                      is_check_class(msg, "check_failure") ~ "\U002757",
@@ -257,7 +259,14 @@ store_msg_val <- function(msg) {
                      TRUE ~ "*"),
     paste0("[", names(msg), "]"),
     purrr::map_chr(msg, "message"),
-    sep = ": ", collapse = "\n"
+    sep = ": "
   )
+  if (rm_valid_check)
+    txt <- purrr::discard(txt, ~grepl("\U002705|spl_non_compound", .x))
+  if (length(txt) > 0 ) {
+    txt <- paste(txt, collapse = "\n")
+  } else {
+    txt <- "No issue reported"
+  }
   txt
 }

--- a/man/store_msg_val.Rd
+++ b/man/store_msg_val.Rd
@@ -4,10 +4,13 @@
 \alias{store_msg_val}
 \title{Store validation output in a simple object}
 \usage{
-store_msg_val(msg)
+store_msg_val(msg, rm_valid_check = FALSE)
 }
 \arguments{
 \item{msg}{validation output}
+
+\item{rm_valid_check}{Boolean, remove valid check and \code{spl_non_compound}
+output, by default FALSE.}
 }
 \description{
 Store validation output in a simple object

--- a/tests/testthat/test_submission.R
+++ b/tests/testthat/test_submission.R
@@ -102,6 +102,9 @@ test_that("Test validation process", {
   expect_contains(attr(check$req_vals, "class"), c("error", "check_error"))
   msg <- store_msg_val(check)
   expect_true(grepl("\U001F6AB.*\U002705", msg))
+  msg2 <- store_msg_val(check, rm_valid_check = TRUE)
+  expect_true(nchar(msg) > nchar(msg2))
+  expect_false(grepl("\U002705", msg2))
 
   ## Additional data
   df <- rbind(df0,


### PR DESCRIPTION
add parameter `store_msg_val()` function to remove valid check (and non compound id check) on output of the function (fixes #44)